### PR TITLE
Fix broken icon URLs in skill.json for all locales

### DIFF
--- a/scripts/ask_create_skill.sh
+++ b/scripts/ask_create_skill.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # ./scripts/ask_create_skill.sh --profile default --endpoint https://test.app --upload-models > ./tmp/ask_create_with_complete_invocation.txt 2>&1 || tru
-set -euo
-set -o pipefail
+set -euo pipefail
 
 # Create an Alexa skill using ASK CLI based on the README instructions
 # - adjusts the `en-US` locale invocation name to "Music Assistant"


### PR DESCRIPTION
<!-- Please provide a short, descriptive title for the change in the PR title. -->

## Summary

- Fixes broken icon URLs in `skill.json` for all locales by updating `smallIconUri` and `largeIconUri` to use correct GitHub raw content URLs with `/refs/heads/master/` path format.

## Related issues

- Fixes broken skill icon URLs across all supported locales

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] CI / tooling

## How has this been tested?

- Verified icon URLs are accessible and display correctly for all locales (en-US, en-GB, en-IN, en-CA, en-AU, fr-FR, fr-CA, es-ES, es-MX, it-IT, pt-BR, de-DE)
- Skill now is correctly created for my locale it-IT, it was affected by wrong url bug before

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] Code builds and lints locally (if applicable).
- [] Relevant tests have been added or updated.
- [] Documentation has been updated where needed.
- [] All continuous integration checks are passing.

## Release notes (optional)

- Fixes broken icon URLs for all skill locales

---

By submitting this pull request, I confirm that you have the right to contribute this work and that it can be used, modified, copied, and redistributed under the project's license.