### PR TITLE
fix: patch certvalidator registry.py to handle asn1crypto>=1.5.1 inco…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,70 @@ if needle in src:
 else:
     print('No patch needed for verifier.py')
 PY
+
+# Apply certvalidator registry.py patch so OS trust-root iteration does not crash
+# with asn1crypto >= 1.5.1. certvalidator 0.11.1 (2016) calls
+# trust_root.subject.hashable for every OS CA cert; asn1crypto 1.5.1 changed
+# NameTypeAndValue internals so that call raises KeyError for certain cert
+# structures present in modern CA stores. Wrap the call in try/except so
+# incompatible trust roots are skipped rather than aborting every Alexa request.
+RUN /app/venv/bin/python - <<'PY'
+import sysconfig, os, sys
+try:
+        site = sysconfig.get_paths()['purelib']
+except Exception:
+        print('Could not determine site-packages path; skipping registry patch')
+        sys.exit(0)
+
+registry_path = os.path.join(site, 'certvalidator', 'registry.py')
+if not os.path.exists(registry_path):
+        print('registry.py not found at', registry_path, '; skipping patch')
+        sys.exit(0)
+
+with open(registry_path, 'r', encoding='utf-8') as f:
+        src = f.read()
+
+needle = (
+    '        for trust_root in trust_roots:\n'
+    '            hashable = trust_root.subject.hashable\n'
+    '            if hashable not in self._subject_map:\n'
+    '                self._subject_map[hashable] = []\n'
+    '            self._subject_map[hashable].append(trust_root)\n'
+    '            if trust_root.key_identifier:\n'
+    '                self._key_identifier_map[trust_root.key_identifier] = trust_root\n'
+    '            self._ca_lookup[trust_root.signature] = True'
+)
+patch = (
+    '        for trust_root in trust_roots:\n'
+    '            try:\n'
+    '                hashable = trust_root.subject.hashable\n'
+    '            except Exception:\n'
+    '                # Skip trust roots whose subject cannot be hashed by this\n'
+    '                # version of asn1crypto (certvalidator 0.11.1 incompatibility)\n'
+    '                continue\n'
+    '            if hashable not in self._subject_map:\n'
+    '                self._subject_map[hashable] = []\n'
+    '            self._subject_map[hashable].append(trust_root)\n'
+    '            if trust_root.key_identifier:\n'
+    '                self._key_identifier_map[trust_root.key_identifier] = trust_root\n'
+    '            self._ca_lookup[trust_root.signature] = True'
+)
+
+if needle in src:
+    new_src = src.replace(needle, patch)
+    backup = registry_path + '.orig'
+    try:
+        if not os.path.exists(backup):
+            with open(backup, 'w', encoding='utf-8') as b:
+                b.write(src)
+        with open(registry_path, 'w', encoding='utf-8') as f:
+            f.write(new_src)
+        print('Patched', registry_path, '(backup at', backup + ')')
+    except Exception as e:
+        print('Failed to write patch:', e)
+else:
+    print('No patch needed for registry.py (needle not found)')
+PY
 # Install ASK CLI (v2) globally so container can run `ask configure`
 RUN npm install -g ask-cli || true
 


### PR DESCRIPTION
## Problem

Every POST request to the Alexa skill endpoint fails with HTTP 500 and the following traceback:

```
ERROR Exception on / [POST]
Traceback (most recent call last):
  File "/app/venv/lib/python3.10/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/app/venv/lib/python3.10/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/app/venv/lib/python3.10/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/app/venv/lib/python3.10/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "src/app.py", line 286, in invoke_skill
    return skill_adapter.dispatch_request()
  File "/app/venv/lib/python3.10/site-packages/flask_ask_sdk/skill_adapter.py", line 238, in dispatch_request
    response = self._webservice_handler.verify_request_and_dispatch(
  File "/app/venv/lib/python3.10/site-packages/ask_sdk_webservice_support/webservice_handler.py", line 145, in verify_request_and_dispatch
    verifier.verify(
  File "/app/venv/lib/python3.10/site-packages/ask_sdk_webservice_support/verifier.py", line 208, in verify
    cert_chain = self._retrieve_and_validate_certificate_chain(cert_url)
  File "/app/venv/lib/python3.10/site-packages/ask_sdk_webservice_support/verifier.py", line 242, in _retrieve_and_validate_certificate_chain
    self._validate_cert_chain(cert_chain)
  File "/app/venv/lib/python3.10/site-packages/ask_sdk_webservice_support/verifier.py", line 352, in _validate_cert_chain
    validator = CertificateValidator(end_cert, intermediate_certs)
  File "/app/venv/lib/python3.10/site-packages/certvalidator/__init__.py", line 64, in __init__
    validation_context = ValidationContext()
  File "/app/venv/lib/python3.10/site-packages/certvalidator/context.py", line 332, in __init__
    self.certificate_registry = CertificateRegistry(
  File "/app/venv/lib/python3.10/site-packages/certvalidator/registry.py", line 97, in __init__
    hashable = trust_root.subject.hashable
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/x509.py", line 1049, in hashable
    return self.chosen.hashable
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/x509.py", line 943, in hashable
    return '\x1E'.join(rdn.hashable for rdn in self)
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/x509.py", line 856, in hashable
    values = self._get_values(self)
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/x509.py", line 926, in _get_values
    [output.update([(ntv['type'].native, ntv.prepped_value)]) for ntv in rdn]
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/x509.py", line 711, in prepped_value
    self._prepped = self._ldap_string_prep(self['value'].native)
  File "/app/venv/lib/python3.10/site-packages/asn1crypto/core.py", line 3522, in __getitem__
    raise KeyError(unwrap(
KeyError: 'No field numbered 1 is present in this asn1crypto.x509.NameTypeAndValue'
```

## Root Cause

`certvalidator 0.11.1` (pulled in transitively by `ask-sdk-webservice-support`) was last released in 2016 and is incompatible with `asn1crypto >= 1.5.1`.

When the Alexa SDK verifies an incoming request, it creates a `CertificateValidator` → `ValidationContext()` → `CertificateRegistry`, which iterates all OS CA trust roots and calls `trust_root.subject.hashable` for each one. In `asn1crypto >= 1.5.1`, internal field-lookup in `NameTypeAndValue` changed and now raises a `KeyError` for certain certificate structures present in modern CA stores — crashing **every single Alexa request** before it reaches the skill logic.

**Why pinning `asn1crypto` is not an option:** `oscrypto >= 1.3.0` (already in `requirements.txt`) explicitly requires `asn1crypto >= 1.5.1`, making a downgrade an irresolvable dependency conflict.

## Fix

Following the same pattern as the existing `verifier.py` Dockerfile patch, a second `RUN` step is added after `pip install` that applies a targeted text substitution to `certvalidator/registry.py` inside the venv.

The trust-root iteration loop is wrapped in `try/except` so any CA cert that `asn1crypto 1.5.1` cannot hash is silently skipped instead of aborting the request handler:

```python
# before
for trust_root in trust_roots:
    hashable = trust_root.subject.hashable  # KeyError on certain modern CA certs
    ...

# after
for trust_root in trust_roots:
    try:
        hashable = trust_root.subject.hashable
    except Exception:
        # Skip trust roots whose subject cannot be hashed by this
        # version of asn1crypto (certvalidator 0.11.1 incompatibility)
        continue
    ...
```

## Related issues

- Fixes # (if applicable)
- Related-to: # (if applicable)

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] CI / tooling

## How has this been tested?

1. Built the image locally with `docker build -t music-assistant-skill-test:fix .`
2. Verified the fix inside the container:
   ```python
   from certvalidator import ValidationContext
   ctx = ValidationContext()
   # succeeds with 146 trust roots loaded — no KeyError
   ```
3. Stopped the original container, started the patched image with the same env/volumes/ports.
4. Sent a real Alexa voice command — no more `Exception on / [POST]`, skill responded correctly.

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] Code builds locally.
- [ ] Relevant tests have been added or updated.
- [ ] Documentation has been updated where needed.
- [ ] All continuous integration checks are passing.

## Release notes

Fixes a crash (`KeyError` in `certvalidator/registry.py`) that caused every incoming Alexa request to fail with HTTP 500 when running with `asn1crypto >= 1.5.1`.

---

By submitting this pull request, I confirm that you have the right to contribute this work and that it can be used, modified, copied, and redistributed under the project's license.
