### PR TITLE
fix: broaden replace_ip_in_url regex to match hostnames, not just IPs

### DIFF
--- a/app/skill/util.py
+++ b/app/skill/util.py
@@ -55,7 +55,7 @@ def replace_ip_in_url(url, hostname):
     if not url:
         return url
     try:
-        new_url = re.sub(r'^https?://\d+\.\d+\.\d+\.\d+(?::\d+)?', hostname, url)
+        new_url = re.sub(r'^https?://[^/]+', hostname, url)
     except re.error:
         # In case the regex fails for some odd reason, just return original
         return url.replace(' ', '%20')


### PR DESCRIPTION
When `publish_ip` in Music Assistant is set to a hostname instead of an IP address, the stream URL looks like `http://stream.example.com:8097/...`. The current regex `\d+\.\d+\.\d+\.\d+` only matches IP addresses, so the URL passes through `replace_ip_in_url()` unchanged — the Echo receives `http://` with port `8097` instead of `https://` on port 443.

Changing the regex to `[^/]+` matches any host (IP or hostname) including the port, so the full `http://host:port` gets replaced with the `https://hostname` from `get_ma_hostname()`.