### PR TITLE
docs: add setup guide and Cloudflare Compose for CGNAT users

### DIFF
--- a/docs/cloudflared/README.md
+++ b/docs/cloudflared/README.md
@@ -1,0 +1,163 @@
+# Music Assistant Alexa Skill — Docker Setup Guide
+
+> **Note:** This guide covers the standard Docker setup including Cloudflare Tunnel support for CGNAT/Starlink users. Echo Show 5 (Gen 3) audio playback is supported out of the box.
+
+---
+
+## What This Project Does
+
+This skill enables **Music Assistant → Amazon Echo** streaming. When you press Play in the Music Assistant UI and select an Echo device as the player, the stream is pushed to the skill and played on your Echo.
+
+### Key Features
+
+| Feature | Status |
+|---|---|
+| Echo Dot / Echo Pop audio playback | ✅ Supported |
+| Echo Show 5 (Gen 3) audio playback | ✅ Supported (Issue #57 fixed) |
+| CGNAT / Starlink / Double-NAT support | ✅ Via Cloudflare Tunnel |
+| URL rewriting (internal → public) | ✅ Built-in |
+| Shared store (MA ↔ Alexa state) | ✅ Built-in |
+
+---
+
+## Prerequisites
+
+- **Music Assistant** running and reachable on your local network
+- **Docker & Docker Compose** installed
+- **Cloudflare Tunnel** (for CGNAT users) OR a **public IP with port forwarding**
+- **Alexa Developer Account** (for ASK CLI skill creation)
+- **Amazon Echo** device
+
+---
+
+## Quick Start
+
+### 1. Clone & Prepare
+
+```bash
+git clone https://github.com/alams154/music-assistant-alexa-skill-prototype.git
+cd music-assistant-alexa-skill-prototype
+
+# Create secrets directory and files
+mkdir -p secrets
+echo "admin" > secrets/app_username.txt
+echo "YOUR_STRONG_PASSWORD" > secrets/app_password.txt  # Use https://www.random.org/passwords/ to generate one
+```
+
+### 2. Configure Docker Compose
+
+**For CGNAT / Starlink / no public IP users:**
+
+Copy `docker-compose.cloudflared.yml` to `docker-compose.yml` and edit the placeholders!
+
+**For users with a public IP and port forwarding:**
+
+The original `docker-compose.yml` from the repository works without modifications. You do not need Cloudflare Tunnel — configure your router to forward port 443 to the skill container and set `SKIP_URL_VALIDATION=false` (or omit it).
+
+### 3. Start the Stack
+
+```bash
+docker compose up -d
+```
+
+### 4. Configure the Alexa Skill
+
+1. Open `https://<YOUR_SKILL_DOMAIN>/setup` or `http://<YOUR_INTERNAL_IP>/setup`
+2. Enter username and password if asked
+3. Complete ASK CLI authentication (Amazon login + OTP)
+4. The skill is created automatically
+5. In the [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask), verify the endpoint matches your `SKILL_HOSTNAME`
+
+### 5. Configure Music Assistant
+
+In Music Assistant:
+- **Settings → Player Providers → Alexa**
+- **API URL:** `http://<SKILL_LOCAL_IP>:5000` (your skill container's local IP)
+- **Auth:** `admin` + your password
+- **Amazon Account:** Connect your Amazon account
+
+---
+
+## Why `SKIP_URL_VALIDATION=true`?
+
+When your server is behind **CGNAT** (Starlink, mobile ISP, etc.), the container cannot reach its own public URL via the internet (no hairpin NAT). The skill would fail URL validation with:
+
+> *"Sorry, I can't reach the audio file."*
+
+`SKIP_URL_VALIDATION=true` bypasses the internal HEAD/GET check. The URL is still rewritten to HTTPS and validated by Alexa's servers externally.
+
+---
+
+## Why `extra_hosts`?
+
+The container must resolve your public domains (`mass-stream.yourdomain.com`) to your **local** Music Assistant instance. Without this, the container tries to reach the public internet and fails behind CGNAT.
+
+---
+
+## Echo Show 5 (Gen 3) — Known Behavior
+
+| Feature | Status |
+|---|---|
+| Audio playback | ✅ Working |
+| Blue listening bar after stop | ✅ Fixed |
+| APL Cover + Title display | ⚠️ Partial — displays on first play, may show "Music Assistant: Now Playing" on subsequent tracks |
+| APL timeline/scrubber | ⚠️ Shows 0:00 (expected for live streams) |
+
+The Echo Show 5 Gen 3 uses APL (Alexa Presentation Language) for its display. Audio playback is stable; the rich metadata display is a secondary enhancement for a future update.
+
+**Workaround:** Say *"Alexa, stop"* then *"Alexa, play Music Assistant"* to refresh the display.
+
+---
+
+## Troubleshooting
+
+### "I can't reach the audio file"
+- Check `MA_HOSTNAME` starts with `https://` (not `http://`)
+- Verify `extra_hosts` points to the correct local IP
+- Ensure `SKIP_URL_VALIDATION=true` for CGNAT
+
+### "No metadata / empty title"
+- Check `/status` endpoint — both `/ma/latest-url` and `/alexa/latest-url` should show data
+- Verify Music Assistant's Alexa Provider is pushing to `http://<SKILL_LOCAL_IP>:5000`
+
+### Echo Show shows blue bar after stop
+- Ensure you're using the latest image: `docker compose pull && docker compose up -d`
+- Restart the container: `docker restart ma_alexa_api`
+
+### Skill not found / 404
+- Run setup again: `https://<YOUR_SKILL_DOMAIN>/setup`
+- Check `ask_data` volume has valid ASK credentials
+
+---
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Amazon Echo │────▶│ Cloudflare      │────▶│  Skill Container│
+│  (Alexa)     │     │  Tunnel         │     │  (Docker)       │
+└─────────────┘     └─────────────────┘     │  Port 5000      │
+                                            └────────┬────────┘
+                                                     │
+                                            ┌────────▼────────┐
+                                            │  Music Assistant│
+                                            │  (local:8095)   │
+                                            └─────────────────┘
+```
+
+1. **MA** pushes stream URL + metadata to skill container (`/ma/push-url`)
+2. **Skill** rewrites internal URL to public domain, stores in shared state
+3. **Alexa** requests stream → Cloudflare Tunnel → Skill → returns public HTTPS URL
+4. **Echo** plays the stream directly from `mass-stream.yourdomain.com`
+
+---
+
+## Contributing
+
+If you have improvements for the APL display or other Echo Show models, PRs are welcome!
+
+---
+
+## License
+
+Same as the original project — see repository LICENSE.

--- a/docs/cloudflared/docker-compose.cloudflared.yml
+++ b/docs/cloudflared/docker-compose.cloudflared.yml
@@ -1,0 +1,197 @@
+# Music Assistant Alexa Skill — Docker Compose (with Cloudflare Tunnel)
+#
+# This configuration is designed for users behind CGNAT / Starlink / Double-NAT
+# who cannot expose their server directly. It includes Cloudflare Tunnel
+# for secure HTTPS access without port forwarding.
+#
+# For users with a public IP and port forwarding, the original docker-compose.yml
+# from the repository works without modifications.
+#
+# See README.md for full setup instructions.
+
+services:
+  music-assistant-skill:
+    image: ghcr.io/alams154/music-assistant-skill:latest
+    container_name: ma_alexa_api
+    environment:
+      # ------------------------------------------------------------------
+      # SKILL_HOSTNAME — Public domain for the Alexa skill endpoint
+      # ------------------------------------------------------------------
+      # This domain must point to your Cloudflare Tunnel (or reverse proxy).
+      # Alexa will call this URL to invoke your skill.
+      # Use ONLY the domain name, no https:// prefix.
+      #
+      # Examples:
+      #   ma-api.mydomain.de, alexa-skill.home-net.com
+      #
+      - SKILL_HOSTNAME=<YOUR_SKILL_DOMAIN>
+
+      # ------------------------------------------------------------------
+      # MA_HOSTNAME — Public domain for Music Assistant streaming
+      # ------------------------------------------------------------------
+      # This domain must point to your Music Assistant instance (via Cloudflare
+      # Tunnel or reverse proxy). The skill rewrites internal MA URLs to this
+      # public hostname so Echo devices can reach the audio stream.
+      # Use ONLY the domain name, no https:// prefix.
+      #
+      # Examples:
+      #   Europe:  mass-stream.mydomain.de, music.myhome.com
+      #
+      - MA_HOSTNAME=<YOUR_MA_DOMAIN>
+
+      # ------------------------------------------------------------------
+      # PORT — Internal port the Flask app listens on
+      # ------------------------------------------------------------------
+      # Default is 5000. Only change if you have a port conflict.
+      - PORT=5000
+
+      # ------------------------------------------------------------------
+      # LOCALE — Language / region for the Alexa skill
+      # ------------------------------------------------------------------
+      # This determines the interaction model, voice responses, and built-in
+      # intents. Must match the locale you selected during skill setup.
+      #
+      # Europe:
+      #   de-DE  = German (Germany)
+      #   de-AT  = German (Austria)
+      #   en-GB  = English (UK)
+      #   fr-FR  = French (France)
+      #   es-ES  = Spanish (Spain)
+      #   it-IT  = Italian (Italy)
+      #   nl-NL  = Dutch (Netherlands)
+      #
+      # Americas:
+      #   en-US  = English (United States)
+      #   en-CA  = English (Canada)
+      #   es-MX  = Spanish (Mexico)
+      #   pt-BR  = Portuguese (Brazil)
+      #
+      # Asia-Pacific:
+      #   en-AU  = English (Australia)
+      #   en-IN  = English (India)
+      #   ja-JP  = Japanese (Japan)
+      #
+      - LOCALE=en-US
+
+      # ------------------------------------------------------------------
+      # AWS_DEFAULT_REGION — Amazon region for ASK CLI / skill deployment
+      # ------------------------------------------------------------------
+      # Must match the region where your Alexa developer account is registered.
+      #
+      # Europe:   eu-west-1  (Ireland)
+      # Americas: us-east-1  (N. Virginia) — default for US/CA accounts
+      # Asia:     ap-northeast-1 (Tokyo)
+      #
+      # If you are in Europe but created your Alexa account on amazon.com,
+      # you may need us-east-1. Check your Alexa Developer Console URL.
+      - AWS_DEFAULT_REGION=us-east-1
+
+      # ------------------------------------------------------------------
+      # SKIP_URL_VALIDATION — Bypass internal URL reachability check
+      # ------------------------------------------------------------------
+      # REQUIRED for CGNAT / Starlink / mobile ISP / DS-Lite / Double-NAT.
+      # When set to "true", the skill skips the HEAD/GET check against the
+      # stream URL. The container cannot reach its own public URL via the
+      # internet because hairpin NAT is blocked by CGNAT.
+      #
+      # Set to "false" (or remove) ONLY if:
+      #   - You have a public IP with port forwarding
+      #   - Your router supports hairpin NAT / NAT loopback
+      #   - The skill container can reach its own public domains
+      #
+      - SKIP_URL_VALIDATION=true
+
+      # ------------------------------------------------------------------
+      # TZ — Timezone for container logs and scheduling
+      # ------------------------------------------------------------------
+      # Set to your local timezone so logs show correct timestamps.
+      #
+      # Europe:    Europe/Berlin, Europe/Vienna, Europe/London, Europe/Paris
+      # Americas:  America/New_York, America/Los_Angeles, America/Chicago
+      # Asia:      Asia/Tokyo, Asia/Singapore, Asia/Dubai
+      # Australia: Australia/Sydney, Australia/Melbourne
+      #
+      - TZ=UTC
+
+      # ------------------------------------------------------------------
+      # APP_USERNAME / APP_PASSWORD — Basic Auth for internal API
+      # ------------------------------------------------------------------
+      # These are mounted as Docker Secrets (file paths), not plain text.
+      # The actual values live in ./secrets/app_username.txt and
+      # ./secrets/app_password.txt on your host.
+      #
+      # Default username from the original project: adminHA
+      # Choose a strong password for the password file.
+      #
+      - APP_USERNAME=/run/secrets/APP_USERNAME
+      - APP_PASSWORD=/run/secrets/APP_PASSWORD
+
+    secrets:
+      - APP_USERNAME
+      - APP_PASSWORD
+
+    ports:
+      - "5000:5000"
+
+    volumes:
+      # ASK CLI credentials and skill state (persisted across restarts)
+      - ./ask_data:/root/.ask
+
+    extra_hosts:
+      # ------------------------------------------------------------------
+      # extra_hosts — Force public domains to resolve to local IPs
+      # ------------------------------------------------------------------
+      # CRITICAL for CGNAT setups. The container cannot reach the public
+      # internet to resolve its own domains, so we tell it the local IP.
+      #
+      # Format: "public-domain:local-ip"
+      #
+      # <YOUR_MA_DOMAIN>  → IP of your Music Assistant server (e.g. 10.0.0.10)
+      # <YOUR_SKILL_DOMAIN> → IP of this skill container (e.g. 10.0.0.9)
+      #
+      # Examples:
+      #   - "mass-stream.home.local:192.168.1.50"
+      #   - "ma-api.home.local:192.168.1.51"
+      #
+      - "<YOUR_MA_DOMAIN>:<MA_LOCAL_IP>"
+      - "<YOUR_SKILL_DOMAIN>:<SKILL_LOCAL_IP>"
+
+    restart: unless-stopped
+
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5000/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # ------------------------------------------------------------------
+  # cloudflared — Cloudflare Tunnel for HTTPS without port forwarding
+  # ------------------------------------------------------------------
+  # This container creates an outbound tunnel to Cloudflare's edge network.
+  # No inbound ports need to be opened on your router or firewall.
+  #
+  # To get a token:
+  #   1. Go to https://one.dash.cloudflare.com
+  #   2. Networks → Tunnels → Create a tunnel
+  #   3. Choose "Cloudflared" → Select Docker
+  #   4. Copy the token from the command: cloudflared tunnel run --token <TOKEN>
+  #   5. Create DNS records for both SKILL_HOSTNAME and MA_HOSTNAME
+      #
+  # The tunnel must route both domains to this Docker host (or separate
+  # tunnels if MA runs on a different host).
+  #
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflare_tunnel
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run --token <YOUR_CLOUDFLARE_TOKEN>
+    depends_on:
+      music-assistant-skill:
+        condition: service_started
+
+secrets:
+  APP_USERNAME:
+    file: ./secrets/app_username.txt
+  APP_PASSWORD:
+    file: ./secrets/app_password.txt


### PR DESCRIPTION
docs: add setup guide and Cloudflare Compose for CGNAT users

## Summary

This PR adds comprehensive documentation and a production-ready Docker Compose configuration for users who cannot expose their server directly — specifically those behind **CGNAT / Starlink / Double-NAT / mobile ISP**.

The original repository assumes a public IP with port forwarding. Many Music Assistant users run on home networks without a public IPv4 address. This documentation closes that gap with a complete, tested setup guide using **Cloudflare Tunnel** for secure HTTPS access without opening any inbound ports.

## Important

**This setup is valid and working if PR [#59](https://github.com/alams154/music-assistant-alexa-skill-prototype/pull/59) gets implemented.**

### What this PR adds

| File | Purpose | Path |
|---|---|---|
| `README.md` | Complete setup guide: prerequisites, Docker Compose configuration, Music Assistant integration, troubleshooting, Echo Show 5 notes, architecture diagram | docs/cloudflared/README.md |
| `docker-compose.cloudflared.yml` | Production-ready Compose file with Cloudflare Tunnel. Includes extensive inline comments for locales (Europe, Americas, Asia-Pacific), timezones, domain examples, and `extra_hosts` explanations. | docs/cloudflared/docker-compose.cloudflared.yml |

### Key sections in README.md

- **Quick Start** — 5 steps from clone to running skill
- **Two Docker Compose paths** — Original `docker-compose.yml` for public-IP users; `docker-compose.cloudflared.yml` for CGNAT/Starlink
- **Why `SKIP_URL_VALIDATION=true`** — Explains the hairpin-NAT problem behind CGNAT
- **Why `extra_hosts`** — Explains local DNS resolution inside the container
- **Echo Show 5 (Gen 3) — Known Behavior** — Documents the fix from PR #2 and current APL limitations
- **Troubleshooting** — 4 common errors with step-by-step solutions
- **Architecture Diagram** — Visual data flow from MA → Skill → Cloudflare → Echo

### Why a separate file for Cloudflare?

The original `docker-compose.yml` is kept untouched for users with public IPs. `docker-compose.cloudflared.yml` is a drop-in alternative that adds the `cloudflared` service. This separation keeps the default simple while offering a tested solution for restricted networks.

## Related issues

- Related-to: PR `fix/shared-store-url-rewriting` (describes the code this documentation references)
- Related-to: PR `fix/echo-show-apl` (describes the Echo Show fix documented here)

## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] CI / tooling

## How has this been tested?

Tested environment:
- Network: Starlink (CGNAT, no public IPv4)
- Tunnel: Cloudflare Tunnel (HTTPS termination + DNS)
- Proxmox host Ubuntu 22.04 and Debian 13 VM
- Docker 28.x with Docker Compose
- Music Assistant: Physical host on local network (10.0.0.10)
- Skill container: Proxmox VM (10.0.0.9)
- Echo devices: Echo Dot (4th Gen), Echo Pop, Echo Show 5 (Gen 3)
- Locale: de-DE (German)
- AWS region: eu-west-1

Validation steps:
1. Follow README.md steps 1-5 on a fresh VM
2. Verify `docker compose up -d` starts both containers
3. Verify `/status` endpoint returns 200 with MA and Alexa data
4. Verify Cloudflare Tunnel routes both domains correctly
5. Verify Music Assistant can push stream URLs to the skill
6. Verify Echo devices play audio and respond to voice commands

## Files changed

| File | Change |
|---|---|
| `README.md` | **New** — Complete setup guide with Cloudflare Tunnel, CGNAT troubleshooting, architecture diagram |
| `docker-compose.cloudflared.yml` | **New** — Production-ready Compose with Cloudflare Tunnel. Extensively commented: locale examples (de-DE, en-US, en-GB, fr-FR, etc.), timezone examples, domain examples for Europe/USA/Global, `extra_hosts` explanation, Cloudflare token setup steps |

## Backward compatibility

- Original `docker-compose.yml` is **not modified**
- Original `README.md` is **not modified** (this is a new file alongside it in docs/cloudflared)
- No code changes — documentation only
- Users with public IPs can ignore this PR entirely

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] Documentation builds and renders correctly (Markdown preview verified).
- [x] Tested with Cloudflare Tunnel + CGNAT (Starlink).
- [x] Tested with Echo Show 5 (Gen 3) and Echo Dot (4th Gen).
- [x] No breaking changes to existing setups.
- [x] Original files remain untouched.

## Release notes

Adds comprehensive setup documentation and `docker-compose.cloudflared.yml` for users behind CGNAT/Starlink. Includes Cloudflare Tunnel configuration and locale/timezone examples.

---

By submitting this pull request, I confirm that I have the right to contribute this work and that it can be used, modified, copied, and redistributed under the project's license.
