### PR TITLE
Fix: rewrite APL audioSources to MA_HOSTNAMEfor screen based echo

### DIFF
--- a/app/skill/data.py
+++ b/app/skill/data.py
@@ -131,6 +131,23 @@ def get_latest(api_hostname: Optional[str] = None,
                 except Exception:
                     logging.exception('Failed rewriting stream URL extension for %s', stream_url)
 
+            # Rewrite local Music Assistant stream host -> public MA_HOSTNAME.
+            # The non-APL branch already does this via replace_ip_in_url(); the APL
+            # path (audioSources) did not, so screen Echos received a private
+            # 192.168 URL and played silence while image fields were rewritten. (#35)
+            # MA_HOSTNAME is read inline here to avoid a data <-> util circular import.
+            if stream_url and isinstance(stream_url, str):
+                try:
+                    ma_hostname = os.environ.get('MA_HOSTNAME', '').strip().strip('"\' ')
+                    if ma_hostname:
+                        if not ma_hostname.startswith(('http://', 'https://')):
+                            ma_hostname = f'https://{ma_hostname}'
+                        ma_hostname = ma_hostname.rstrip('/')
+                        stream_url = re.sub(r'^https?://[^/]+', ma_hostname, stream_url)
+                        stream_url = stream_url.replace(' ', '%20')
+                except Exception:
+                    logging.exception('Failed rewriting stream URL host for %s', stream_url)
+
             info.update({
                 'audioSources': stream_url,
                 'backgroundImageSource': image,


### PR DESCRIPTION
Fixes #35

## Summary
On APL devices (Echo Show/Spot), audio never plays though album art and metadata render. `data.py get_latest()` rewrites the stream extension (.flac→.mp3) but not the host, writing the still-local `streamUrl` into `data.info["audioSources"]`. The APL document binds the audio player to `${audioSources}` (apl_document.json, apl.py), and neither apl.py nor util.py rewrites `audioSources` — only the image sources. The non-APL path is unaffected: util.py already calls `replace_ip_in_url()` before building the PlayDirective. Net effect: screen Echos show art and play silence.

## Fix
After the extension rewrite in data.py, rewrite the stream URL's scheme+host(+port) to MA_HOSTNAME and %20-encode path spaces. No-op when MA_HOSTNAME is unset. Read inline to avoid a data ↔ util circular import.

## Scope
Single-file change; `audioSources` is the only APL audio binding, so this is the complete fix. Non-APL path and image rewrites untouched.

## Related issues
- Fixes #35

## How has this been tested?
Verified on a real Echo Show (APL) with MA_HOSTNAME set to a public HTTPS host.
- Before: `/status` showed `audioSources` as local `http://192.168.x.x:8097/…mp3` while cover/background images were already `https://<MA_HOSTNAME>/…`; art displayed, no audio.
- After: `audioSources` becomes `https://<MA_HOSTNAME>/flow/…mp3` and audio plays.
- Reviewer steps: set MA_HOSTNAME to a public host, play a track to an APL/screen Echo, check `/status` — `audioSources` should match the public host, not a local IP. Screenless (non-APL) Echo also tested, unchanged.

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] Code builds and lints locally.
- [ ] Relevant tests have been added or updated.
- [x] Documentation has been updated where needed (code comments).
- [ ] All continuous integration checks are passing.

## Release notes
Fixes no audio on APL/screen Echo devices — APL `audioSources` now rewritten to MA_HOSTNAME like the non-APL path and image sources. (#35)