### PR TITLE
fix: implement missing util.play_later for PlaybackNearlyFinished

### DIFF
--- a/app/skill/lambda_function.py
+++ b/app/skill/lambda_function.py
@@ -398,9 +398,19 @@ class PlaybackNearlyFinishedHandler(AbstractRequestHandler):
             logger.warning("No stream url available for PlaybackNearlyFinished")
             return handler_input.response_builder.response
 
+        # ENQUEUE must chain from the stream that is currently playing.
+        current_token = None
+        try:
+            context = handler_input.request_envelope.context
+            if context and context.audio_player:
+                current_token = context.audio_player.token
+        except AttributeError:
+            current_token = None
+
         return util.play_later(
             url=url,
-            response_builder=handler_input.response_builder
+            response_builder=handler_input.response_builder,
+            expected_previous_token=current_token
         )
 
 

--- a/app/skill/util.py
+++ b/app/skill/util.py
@@ -182,6 +182,75 @@ def play(url, offset, text, response_builder, supports_apl=False):
     return response_builder.response
 
 
+def play_later(url, response_builder, expected_previous_token=None):
+    """Enqueue the next stream without interrupting the one now playing.
+
+    Called from AudioPlayer.PlaybackNearlyFinished.
+
+    https://developer.amazon.com/docs/custom-skills/audioplayer-interface-reference.html#play
+    ENQUEUE: Add the specified stream to the end of the current queue. This
+    does not impact the currently playing stream.
+
+    Two constraints make this different from play():
+
+    1. Alexa rejects a PlaybackNearlyFinished response that carries
+       outputSpeech, a reprompt, or shouldEndSession, answering with
+       System.ExceptionEncountered / INVALID_RESPONSE. So this only ever adds
+       a directive, and never speaks or ends the session.
+    2. ENQUEUE requires expectedPreviousToken to match the token of the stream
+       that is currently playing. Without it the directive is discarded.
+    """
+    # type: (str, ResponseFactory, Optional[str]) -> Response
+
+    try:
+        hostname = get_ma_hostname(raise_on_http_scheme=True)
+    except ValueError:
+        logging.error(
+            'MA_HOSTNAME uses an unsupported scheme (http); cannot enqueue next stream.')
+        return response_builder.response
+
+    if not hostname:
+        logging.error('MA_HOSTNAME is not set; cannot enqueue next stream.')
+        return response_builder.response
+
+    url = replace_ip_in_url(url, hostname)
+
+    if not expected_previous_token:
+        # Nothing to chain from. Enqueueing anyway would be dropped by Alexa.
+        logging.warning(
+            'No current playback token available; skipping enqueue of next stream.')
+        return response_builder.response
+
+    if url == expected_previous_token:
+        # The API is still serving the stream that is playing. In flow mode the
+        # queue is a single continuous stream, so re-enqueueing it would restart
+        # playback in a loop rather than advance. Let it finish instead.
+        logging.info(
+            'Next stream URL matches the current one; nothing to enqueue.')
+        return response_builder.response
+
+    response_builder.add_directive(
+        PlayDirective(
+            play_behavior=PlayBehavior.ENQUEUE,
+            audio_item=AudioItem(
+                stream=Stream(
+                    token=url,
+                    url=url,
+                    offset_in_milliseconds=0,
+                    expected_previous_token=expected_previous_token
+                )
+            )
+        )
+    )
+
+    try:
+        push_alexa_metadata(url)
+    except Exception:
+        logging.exception('Error while preparing Alexa API push payload')
+
+    return response_builder.response
+
+
 def stop(text, response_builder, supports_apl=False):
     """Issue stop directive to stop the audio.
 


### PR DESCRIPTION
## Problem

`PlaybackNearlyFinishedHandler` calls `util.play_later()` (`app/skill/lambda_function.py:401`), but **no such function exists in `util.py`**. On `master` today, `play_later` appears exactly once in the whole repo: at the call site.

Every `AudioPlayer.PlaybackNearlyFinished` request therefore raises, is swallowed by `CatchAllExceptionHandler`, and Alexa answers with `System.ExceptionEncountered` / `INVALID_RESPONSE`:

```
INFO  In PlaybackNearlyFinishedHandler
INFO  Playback nearly finished
INFO  In CatchAllExceptionHandler
ERROR module 'skill.util' has no attribute 'play_later'
  File "/app/src/skill/lambda_function.py", line 401, in handle
    return util.play_later(
AttributeError: module 'skill.util' has no attribute 'play_later'
```

Observed effect: playback starts normally and then stops at the end of the first stream, because the handler that should queue what comes next never returns a directive.

## Fix

Implements `util.play_later()`, and passes the current playback token from the handler.

It differs from `play()` in two ways this callback requires:

1. **No speech, no session flag.** Alexa rejects a `PlaybackNearlyFinished` response carrying `outputSpeech`, a `reprompt`, or `shouldEndSession`. The device reports it verbatim as:

   > The following directives are not supported: Response may not contain an outputSpeech, Response may not contain an reprompt, Response may not have shouldEndSession set to false

   So `play_later()` only ever adds a directive.

2. **`ENQUEUE` needs `expectedPreviousToken`.** Per the [AudioPlayer reference](https://developer.amazon.com/docs/custom-skills/audioplayer-interface-reference.html#play), `ENQUEUE` appends to the queue without disturbing what is playing, and requires `expectedPreviousToken` to match the current stream or the directive is discarded. `PlaybackNearlyFinishedHandler` now reads it from `context.audio_player.token`.

It also skips enqueueing when the API returns the stream that is already playing. In flow mode the queue is a single continuous stream, so re-enqueueing the same URL would restart it in a loop rather than advance.

Hostname sanitising and `replace_ip_in_url()` are applied as in `play()`. Failure paths log and return an empty response rather than raising, so a transient problem can no longer take down the session.

## Related

Touches the same directive as #68 (`expectedPreviousToken` on `REPLACE_ALL`). This PR only adds the `ENQUEUE` path and does not change `play()`.

## Test plan

- [x] `python -m py_compile app/skill/util.py app/skill/lambda_function.py`
- [x] `AudioPlayer.PlaybackNearlyFinished` no longer raises `AttributeError`
- [x] Response contains no `outputSpeech` / `reprompt` / `shouldEndSession`
- [ ] Multi-track playback continues past the first stream on a real device
